### PR TITLE
ops/GO-85

### DIFF
--- a/webhook-stream-version/README.md
+++ b/webhook-stream-version/README.md
@@ -1,0 +1,48 @@
+# Utility di aggiornamento versioni per pn-WebhookStreams
+
+Questo script permette di aggiornare gli elementi nella tabella DynamoDB pn-WebhookStreams aggiungendo l'attributo `version`.
+
+## Prerequisiti
+
+- Node.js >= 18.0.0 installato
+- Configurazione AWS CLI con le credenziali appropriate
+- File CSV contenente i dati degli stream da aggiornare
+
+## Struttura del File CSV
+
+Il file CSV deve contenere le seguenti colonne:
+- `hashKey`: Chiave di partizione dell'elemento
+- `sortKey`: Chiave di ordinamento dell'elemento
+- `version`: Valore della versione da impostare
+
+## Utilizzo
+
+```bash
+node webhook-stream-version.js --envName|-e <ambiente> --csvFile|-f <percorso>
+```
+
+### Parametri
+
+- `--envName`, `-e`: Ambiente di destinazione (dev|uat|test|prod|hotfix)
+- `--csvFile`, `-f`: Percorso del file CSV contenente i dati degli stream
+- `--help`, `-h`: Visualizza il messaggio di aiuto
+
+### Esempi
+
+```bash
+# Aggiornamento degli stream in ambiente dev
+node webhook-stream-version.js -e dev -f ./streams.csv
+```
+
+## Output
+
+Lo script produce un riepilogo dell'esecuzione con:
+- Numero totale di elementi processati
+- Numero di elementi aggiornati con successo
+- Numero di elementi saltati (versione già presente)
+- Numero di aggiornamenti falliti
+
+## Note
+
+- Lo script verifica l'esistenza dell'elemento prima dell'aggiornamento
+- Gli elementi che già possiedono l'attributo `version` vengono saltati

--- a/webhook-stream-version/package-lock.json
+++ b/webhook-stream-version/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "webhook-stream-version",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webhook-stream-version",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "csv-parse": "^5.5.0",
+        "pn-common": "file:../pn-common/"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../../pn-commons": {
+      "extraneous": true
+    },
+    "../pn-common": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@aws-sdk/client-cloudformation": "^3.658.0",
+        "@aws-sdk/client-cloudwatch": "^3.709.0",
+        "@aws-sdk/client-cloudwatch-logs": "^3.614.0",
+        "@aws-sdk/client-dynamodb": "^3.602.0",
+        "@aws-sdk/client-ecs": "^3.731.1",
+        "@aws-sdk/client-eventbridge": "^3.614.0",
+        "@aws-sdk/client-kinesis": "^3.614.0",
+        "@aws-sdk/client-kms": "^3.670.0",
+        "@aws-sdk/client-lambda": "^3.670.0",
+        "@aws-sdk/client-s3": "^3.645.0",
+        "@aws-sdk/client-sqs": "^3.600.0",
+        "@aws-sdk/client-sts": "^3.675.0",
+        "@aws-sdk/credential-provider-ini": "^3.598.0",
+        "@aws-sdk/util-dynamodb": "^3.602.0",
+        "csv-parse": "^5.5.6"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    },
+    "node_modules/pn-common": {
+      "resolved": "../pn-common",
+      "link": true
+    }
+  }
+}

--- a/webhook-stream-version/package.json
+++ b/webhook-stream-version/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "webhook-stream-version",
+  "version": "1.0.0",
+  "description": "Script to update version attribute for items in pn-WebhookStreams DynamoDB table",
+  "type": "module",
+  "main": "webhook-stream-version.js",
+  "scripts": {
+    "start": "node webhook-stream-version.js"
+  },
+  "author": "PagoPA",
+  "license": "ISC",
+  "dependencies": {
+    "csv-parse": "^5.5.0",
+    "pn-common": "file:../pn-common/"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/webhook-stream-version/webhook-stream-version.js
+++ b/webhook-stream-version/webhook-stream-version.js
@@ -1,0 +1,210 @@
+import { parseArgs } from 'util';
+import { parse } from 'csv-parse/sync';
+import { readFileSync } from 'fs';
+import { AwsClientsWrapper } from "pn-common";
+
+const VALID_ENVIRONMENTS = ['dev', 'uat', 'test', 'prod', 'hotfix'];
+
+/**
+ * Validates command line arguments
+ * @returns {Object} Parsed and validated arguments
+ */
+function validateArgs() {
+    const usage = `
+Usage: node webhook-stream-version.js --envName|-e <environment> --csvFile|-f <path>
+
+Description:
+    Updates DynamoDB items in pn-WebhookStreams table with version information.
+
+Parameters:
+    --envName, -e     Required. Environment to update (dev|uat|test|prod|hotfix)
+    --csvFile, -f     Required. Path to the CSV file containing stream data
+    --help, -h        Display this help message`;
+
+    const args = parseArgs({
+        options: {
+            envName: { type: "string", short: "e" },
+            csvFile: { type: "string", short: "f" },
+            help: { type: "boolean", short: "h" }
+        },
+        strict: true
+    });
+
+    if (args.values.help) {
+        console.log(usage);
+        process.exit(0);
+    }
+
+    if (!args.values.envName || !args.values.csvFile) {
+        console.error("Error: Missing required parameters");
+        console.log(usage);
+        process.exit(1);
+    }
+
+    if (!VALID_ENVIRONMENTS.includes(args.values.envName)) {
+        console.error(`Error: Invalid environment. Must be one of: ${VALID_ENVIRONMENTS.join(', ')}`);
+        process.exit(1);
+    }
+
+    return args.values;
+}
+
+/**
+ * Tests SSO credentials for AWS client
+ * @param {AwsClientsWrapper} awsClient - AWS client wrapper
+ */
+async function testSsoCredentials(awsClient) {
+    try {
+        awsClient._initSTS();
+        await awsClient._getCallerIdentity();
+    } catch (error) {
+        if (error.name === 'CredentialsProviderError' ||
+            error.message?.includes('expired') ||
+            error.message?.includes('credentials')) {
+            console.error('\n=== SSO Authentication Error ===');
+            console.error('Your SSO session has expired or is invalid.');
+            console.error('Please run the following commands:');
+            console.error('1. aws sso logout');
+            console.error(`2. aws sso login --profile ${awsClient.ssoProfile}`);
+            process.exit(1);
+        }
+        throw error;
+    }
+}
+
+/**
+ * Parses input CSV file
+ * @param {string} filePath - Path to CSV file
+ * @returns {Array<Object>} Parsed records
+ */
+function parseCsvFile(filePath) {
+    try {
+        const fileContent = readFileSync(filePath, 'utf-8');
+        const records = parse(fileContent, {
+            columns: true,
+            skip_empty_lines: true
+        });
+
+        // Validate required columns
+        const requiredColumns = ['hashKey', 'sortKey', 'version'];
+        const missingColumns = requiredColumns.filter(col => 
+            !records[0] || typeof records[0][col] === 'undefined'
+        );
+
+        if (missingColumns.length > 0) {
+            throw new Error(`Missing required columns: ${missingColumns.join(', ')}`);
+        }
+
+        return records;
+    } catch (error) {
+        console.error('Error reading/parsing CSV file:', error);
+        process.exit(1);
+    }
+}
+
+/**
+ * Prints execution summary
+ * @param {Object} stats - Execution statistics
+ */
+function printSummary(stats) {
+    console.log('\n=== Execution Summary ===');
+    console.log(`\nTotal items processed: ${stats.total}`);
+    console.log(`Items updated: ${stats.updated}`);
+    console.log(`Items skipped (version already exists): ${stats.skipped}`);
+    console.log(`Failed updates: ${stats.failed}`);
+}
+
+/**
+ * Main execution function
+ */
+async function main() {
+    const args = validateArgs();
+    const { envName, csvFile } = args;
+
+    // Initialize AWS client
+    const coreClient = new AwsClientsWrapper('core', envName);
+    await testSsoCredentials(coreClient);
+    coreClient._initDynamoDB();
+
+    // Parse CSV file
+    const records = parseCsvFile(csvFile);
+    console.log(`Processing ${records.length} records...`);
+
+    const stats = {
+        total: records.length,
+        updated: 0,
+        skipped: 0,
+        failed: 0
+    };
+
+    // Process each record
+    for (const record of records) {
+        try {
+            // Query the item
+            const result = await coreClient._dynamicQueryRequest(
+                'pn-WebhookStreams',
+                {
+                    hashKey: {
+                        codeAttr: '#h',
+                        codeValue: ':h',
+                        value: record.hashKey,
+                        operator: '='
+                    },
+                    sortKey: {
+                        codeAttr: '#s',
+                        codeValue: ':s',
+                        value: record.sortKey,
+                        operator: '='
+                    }
+                },
+                'and'
+            );
+
+            if (result.Items && result.Items.length > 0) {
+                const item = result.Items[0];
+                
+                // Check if version exists
+                if (item.version) {
+                    console.log(`Skipping ${record.hashKey}/${record.sortKey} - version already exists`);
+                    stats.skipped++;
+                    continue;
+                }
+
+                // Update item with version
+                await coreClient._updateItem(
+                    'pn-WebhookStreams',
+                    {
+                        hashKey: record.hashKey,
+                        sortKey: record.sortKey
+                    },
+                    {
+                        version: {
+                            codeAttr: '#v',
+                            codeValue: ':v',
+                            value: record.version
+                        }
+                    },
+                    'SET'
+                );
+
+                console.log(`Updated ${record.hashKey}/${record.sortKey} with version ${record.version}`);
+                stats.updated++;
+            } else {
+                console.error(`Item not found: ${record.hashKey}/${record.sortKey}`);
+                stats.failed++;
+            }
+        } catch (error) {
+            console.error(`Error processing ${record.hashKey}/${record.sortKey}:`, error);
+            stats.failed++;
+        }
+    }
+
+    // Print summary
+    printSummary(stats);
+}
+
+// Start execution with error handling
+main().catch(err => {
+    console.error('Script failed:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
Issue JIRA di riferimento: [GO-85](https://pagopa.atlassian.net/browse/GO-85)

Lo script permette di aggiornare gli elementi nella tabella DynamoDB pn-WebhookStreams a cui manca l'attributo `version`.
Il file CSV atteso come input deve contenere le seguenti colonne:
- `hashKey`: Chiave di partizione dell'elemento
- `sortKey`: Chiave di ordinamento dell'elemento
- `version`: Valore della versione da impostare

Gli elementi che già possiedono l'attributo `version` vengono saltati. Al termine dell'esecuzione viene prodotto un riepilogo con:
- Numero totale di elementi processati
- Numero di elementi aggiornati con successo
- Numero di elementi saltati (versione già presente)
- Numero di aggiornamenti falliti
