### PR TITLE
Ops/go 109

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ legal_conservation_error_extractor/result
 
 ### Miscellaneous ###
 *.csv
+*.txt
 
 ### Automation Scripts ###
 automation_scripts/*

--- a/manage-request-status/README.md
+++ b/manage-request-status/README.md
@@ -62,13 +62,13 @@ node index.js -i input.csv -c restore_request_status [-e environment]
 
 ```bash
 # Salva lo stato corrente
-node index.js -i richieste.txt -c save_request_status -e dev
+node index.js -i requestIds.txt -c save_request_status -e dev
 
 # Imposta lo stato su ACCEPTED
-node index.js -i richieste.txt -c set_request_status -s ACCEPTED -e dev
+node index.js -i requestIds.txt -c set_request_status -s ACCEPTED -e dev
 
 # Ripristina lo stato dal CSV
-node index.js -i salvato.csv -c restore_request_status -e dev
+node index.js -i saved.csv -c restore_request_status -e dev
 ```
 
 ## Output

--- a/manage-request-status/README.md
+++ b/manage-request-status/README.md
@@ -1,0 +1,84 @@
+# Strumento di Gestione Stato Richieste
+
+Utility per la gestione degli stati delle richieste in DynamoDB, che permette di salvare, impostare e ripristinare gli stati di multiple richieste.
+
+## Prerequisiti
+
+- Node.js >= 18.0.0
+- Credenziali AWS configurate
+- Accesso alla tabella DynamoDB `pn-EcRichiesteMetadati`
+
+## Installazione
+
+```bash
+npm install
+```
+
+## Utilizzo
+
+Lo script supporta tre operazioni principali:
+
+### 1. Salvataggio Stato Richieste
+
+Salva lo stato corrente delle richieste in un file CSV:
+
+```bash
+node index.js -i input.txt -c save_request_status [-e environment]
+```
+
+- `input.txt`: File di testo contenente un requestId per riga
+- L'output verrà salvato in `results/saved.csv`
+
+### 2. Impostazione Stato Richieste
+
+Aggiorna lo stato di multiple richieste:
+
+```bash
+node index.js -i input.txt -c set_request_status -s NUOVO_STATO [-e environment]
+```
+
+- `input.txt`: File di testo contenente un requestId per riga
+- `NUOVO_STATO`: Il valore dello stato da impostare per tutte le richieste
+
+### 3. Ripristino Stato Richieste
+
+Ripristina gli stati da un file CSV precedentemente salvato:
+
+```bash
+node index.js -i input.csv -c restore_request_status [-e environment]
+```
+
+- `input.csv`: File CSV con colonne `requestId` e `statusRequest`
+
+### Parametri Comuni
+
+- `-i, --inputFile`: Percorso del file di input (obbligatorio)
+- `-c, --command`: Comando da eseguire (obbligatorio)
+- `-e, --envName`: Nome dell'ambiente (opzionale: dev|uat|test|prod|hotfix)
+- `-s, --status`: Nuovo valore dello stato (obbligatorio per set_request_status)
+- `-h, --help`: Visualizza il messaggio di aiuto
+
+### Esempi
+
+```bash
+# Salva lo stato corrente
+node index.js -i richieste.txt -c save_request_status -e dev
+
+# Imposta lo stato su ACCEPTED
+node index.js -i richieste.txt -c set_request_status -s ACCEPTED -e dev
+
+# Ripristina lo stato dal CSV
+node index.js -i salvato.csv -c restore_request_status -e dev
+```
+
+## Output
+
+Tutte le operazioni generano un file CSV nella directory `results` contenente:
+- requestId
+- statusRequest (corrente o aggiornato)
+
+## Gestione Errori
+
+- Le richieste non valide vengono registrate ma non bloccano il processo
+- I risultati vengono salvati anche se alcune richieste falliscono
+- I messaggi di errore dettagliati vengono visualizzati nella console

--- a/manage-request-status/index.js
+++ b/manage-request-status/index.js
@@ -1,0 +1,250 @@
+import { parseArgs } from 'util';
+import { createReadStream, createWriteStream, mkdirSync, existsSync } from 'fs';
+import { createInterface } from 'readline';
+import { AwsClientsWrapper } from "pn-common";
+import { pipeline } from 'stream/promises';
+import { Transform } from 'stream';
+import { stringify } from 'csv-stringify';
+
+const VALID_ENVIRONMENTS = ['dev', 'uat', 'test', 'prod', 'hotfix'];
+const VALID_COMMANDS = ['save_request_status', 'set_request_status', 'restore_request_status'];
+
+function validateArgs() {
+    const usage = `
+Usage: node index.js --inputFile|-i <path> --command|-c <command> [--envName|-e <environment>] [--status|-s <status>]
+
+Description:
+    Query and optionally update request status in DynamoDB.
+
+Commands:
+    save_request_status     Save current status to CSV
+    set_request_status      Update status in DynamoDB (requires --status)
+    restore_request_status  Update status in DynamoDB using values from CSV input
+
+Parameters:
+    --inputFile, -i    Required. Path to input file (TXT for save/set, CSV for restore)
+    --command, -c      Required. Command to execute
+    --envName, -e      Optional. Environment name (dev|uat|test|prod|hotfix)
+    --status, -s       Required for set_request_status. New status value
+    --help, -h        Display this help message`;
+
+    const args = parseArgs({
+        options: {
+            inputFile: { type: "string", short: "i" },
+            command: { type: "string", short: "c" },
+            envName: { type: "string", short: "e" },
+            status: { type: "string", short: "s" },
+            help: { type: "boolean", short: "h" }
+        },
+        strict: true
+    });
+
+    if (args.values.help) {
+        console.log(usage);
+        process.exit(0);
+    }
+
+    if (!args.values.inputFile || !args.values.command) {
+        console.error("Error: Missing required parameters");
+        console.log(usage);
+        process.exit(1);
+    }
+
+    if (!VALID_COMMANDS.includes(args.values.command)) {
+        console.error(`Error: Invalid command. Must be one of: ${VALID_COMMANDS.join(', ')}`);
+        process.exit(1);
+    }
+
+    if (args.values.command === 'set_request_status' && !args.values.status) {
+        console.error("Error: --status is required for set_request_status command");
+        process.exit(1);
+    }
+
+    if (args.values.command === 'restore_request_status' && !args.values.inputFile.toLowerCase().endsWith('.csv')) {
+        console.error("Error: restore_request_status requires a CSV input file");
+        process.exit(1);
+    }
+
+    if (args.values.envName && !VALID_ENVIRONMENTS.includes(args.values.envName)) {
+        console.error(`Error: Invalid environment. Must be one of: ${VALID_ENVIRONMENTS.join(', ')}`);
+        process.exit(1);
+    }
+
+    return args.values;
+}
+
+/**
+ * Reads and processes records from input file based on command type
+ * @param {string} inputFile - Path to the input file
+ * @param {string} command - Command to execute
+ * @returns {Promise<Array<{requestId: string, statusRequest?: string}>>}
+ */
+async function readInputFile(inputFile, command) {
+    const fileStream = createReadStream(inputFile);
+    const records = [];
+    
+    if (command === 'restore_request_status') {
+        // Read CSV file with requestId and statusRequest columns
+        const parser = parse({ 
+            columns: true,
+            skip_empty_lines: true
+        });
+        
+        for await (const record of fileStream.pipe(parser)) {
+            if (record.requestId && record.statusRequest) {
+                records.push({
+                    requestId: record.requestId.trim(),
+                    statusRequest: record.statusRequest.trim()
+                });
+            }
+        }
+    } else {
+        // Read TXT file with requestIds only
+        const rl = createInterface({
+            input: fileStream,
+            crlfDelay: Infinity
+        });
+
+        for await (const line of rl) {
+            if (line.trim()) {
+                records.push({ requestId: line.trim() });
+            }
+        }
+    }
+
+    return records;
+}
+
+/**
+ * Processes a single request ID in DynamoDB
+ * @param {string} requestId - Request ID to process
+ * @param {AwsClientsWrapper} awsClient - AWS client instance
+ * @param {string} command - Command to execute
+ * @param {string} newStatus - New status to set (for set_request_status)
+ * @param {string} existingStatus - Existing status (for restore_request_status)
+ * @returns {Promise<{requestId: string, statusRequest: string} | null>}
+ */
+async function processRequestId(requestId, awsClient, command, newStatus, existingStatus) {
+    try {
+        const result = await awsClient._queryRequest('pn-EcRichiesteMetadati', 'requestId', requestId);
+        
+        if (!result.Items || result.Items.length === 0) {
+            console.warn(`No items found for requestId: ${requestId}`);
+            return null;
+        }
+
+        const item = result.Items[0];
+
+        if (command === 'save_request_status') {
+            return {
+                requestId: requestId,
+                statusRequest: item.statusRequest?.S || ''
+            };
+        } else {
+            const statusToSet = command === 'restore_request_status' ? existingStatus : newStatus;
+            const now = new Date().toISOString();
+            await awsClient._updateItem(
+                'pn-EcRichiesteMetadati',
+                { requestId: { value: requestId } },
+                {
+                    statusRequest: { value: statusToSet },
+                    lastUpdateTimestamp: { value: now }
+                },
+                'set'
+            );
+            console.log(`Updated status for ${requestId} to ${statusToSet}`);
+            return {
+                requestId: requestId,
+                statusRequest: statusToSet
+            };
+        }
+    } catch (error) {
+        console.error(`Error processing ${requestId}:`, error);
+        return null;
+    }
+}
+
+/**
+ * Process all request IDs from the input file
+ * @param {string} inputFile - Path to the input file
+ * @param {AwsClientsWrapper} awsClient - AWS client instance
+ * @param {string} command - Command to execute
+ * @param {string} newStatus - New status to set (for set_request_status)
+ * @returns {Promise<Array<{requestId: string, statusRequest: string}>>}
+ */
+async function processInputFile(inputFile, awsClient, command, newStatus) {
+    const results = [];
+    const records = await readInputFile(inputFile, command);
+
+    for (const record of records) {
+        const result = await processRequestId(
+            record.requestId, 
+            awsClient, 
+            command, 
+            newStatus, 
+            record.statusRequest
+        );
+        if (result) {
+            results.push(result);
+        }
+    }
+
+    return results;
+}
+
+/**
+ * Saves results to a CSV file in the results directory
+ * @param {Array<{requestId: string, statusRequest: string}>} results - Results to save
+ * @returns {Promise<void>}
+ */
+async function saveResults(results) {
+    if (!existsSync('results')) {
+        mkdirSync('results');
+    }
+
+    const writeable = createWriteStream('results/saved.csv');
+    const stringifier = stringify({ 
+        header: true, 
+        columns: ['requestId', 'statusRequest']
+    });
+    
+    await pipeline(
+        Transform.from(results),
+        stringifier,
+        writeable
+    );
+
+    console.log('Results saved to results/saved.csv');
+}
+
+/**
+ * Main function that orchestrates the request status management process
+ * @returns {Promise<void>}
+ */
+async function main() {
+    // Parse and validate command line arguments
+    const args = validateArgs();
+    const { inputFile, command, envName, status } = args;
+
+    // Initialize AWS client with optional environment
+    const awsClient = envName 
+        ? new AwsClientsWrapper('confinfo', envName)
+        : new AwsClientsWrapper();
+    
+    awsClient._initDynamoDB();
+
+    try {
+        // Process requests and save results
+        const results = await processInputFile(inputFile, awsClient, command, status);
+        await saveResults(results);
+    } catch (error) {
+        console.error('Error during execution:', error);
+        process.exit(1);
+    }
+}
+
+// Start execution
+main().catch(error => {
+    console.error('Fatal error during execution:', error);
+    process.exit(1);
+});

--- a/manage-request-status/index.js
+++ b/manage-request-status/index.js
@@ -293,10 +293,16 @@ async function processInputFile(inputFile, awsClient, command, newStatus) {
  * Generates a CSV file with requestId and statusRequest columns
  * 
  * @param {Array<{requestId: string, statusRequest: string}>} results - Array of processed requests
+ * @param {string} command - The command being executed
  * @returns {Promise<void>}
  * @throws {Error} If directory creation or file writing fails
  */
-async function saveResults(results) {
+async function saveResults(results, command) {
+    // Only save results to CSV for save_request_status command
+    if (command !== 'save_request_status') {
+        return;
+    }
+
     /** Create results directory if it doesn't exist */
     if (!existsSync('results')) {
         mkdirSync('results');
@@ -358,8 +364,8 @@ async function main() {
     try {
         /** Process all requests from input file */
         const results = await processInputFile(inputFile, awsClient, command, status);
-        /** Save results to CSV file */
-        await saveResults(results);
+        /** Save results to CSV only for save_request_status command */
+        await saveResults(results, command);
     } catch (error) {
         console.error('Error during execution:', error);
         process.exit(1);  // Exit with error

--- a/manage-request-status/package-lock.json
+++ b/manage-request-status/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "manage-request-status",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "manage-request-status",
+      "version": "1.0.0",
+      "dependencies": {
+        "csv-stringify": "^6.0.0",
+        "pn-common": "file:../../pn-common"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "../../pn-common": {},
+    "node_modules/csv-stringify": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.2.tgz",
+      "integrity": "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==",
+      "license": "MIT"
+    },
+    "node_modules/pn-common": {
+      "resolved": "../../pn-common",
+      "link": true
+    }
+  }
+}

--- a/manage-request-status/package.json
+++ b/manage-request-status/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "manage-request-status",
+  "version": "1.0.0",
+  "description": "Tool to manage request status in DynamoDB",
+  "type": "module",
+  "main": "index.js",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "start": "node index.js"
+  },
+  "author": "PagoPA",
+  "license": "ISC",
+  "dependencies": {
+    "csv-stringify": "^6.0.0",
+    "pn-common": "file:../../pn-common"
+  }
+}


### PR DESCRIPTION
Issue JIRA di riferimento: [GO-109](https://pagopa.atlassian.net/browse/GO-109)

Lo script supporta tre operazioni principali sulla pn-EcRichiesteMetadati:

- save_request_status: salva l'attuale statusRequest in un file CSV sotto `results/`:
- set_request_status: aggiorna lo stato di multiple richieste:
- restore_request_status: ripristina gli stati da un file CSV precedentemente salvato:

Le richieste non valide vengono registrate ma non bloccano il processo, e i risultati vengono salvati anche se alcune richieste dovessero fallire.

[GO-109]: https://pagopa.atlassian.net/browse/GO-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ