### PR TITLE
ops/GO-116

### DIFF
--- a/update-analog-costs/README.md
+++ b/update-analog-costs/README.md
@@ -1,0 +1,45 @@
+# Utility di Aggiornamento Costi Notifiche Analogiche
+
+Questo script permette di aggiornare i costi delle notifiche analogiche attraverso chiamate API e messaggi SQS a seconda dello stato della notifica.
+
+## Prerequisiti
+
+- Node.js >= 18.0.0
+- AWS CLI configurato con profilo SSO appropriato
+- File CSV contenente i dati delle notifiche da aggiornare
+
+## Struttura del File CSV
+
+Il file CSV deve contenere le seguenti colonne:
+- `IUN`
+- `timelineElementId`
+- `category`
+- `costo timelineElementId`
+- `vat`
+- `recipientIndex`
+- `noticeCode`
+- `creditorTaxId`
+- `eventTimestamp`
+- `notificationFeePolicy`
+- `paFee`
+
+## Utilizzo
+
+```bash
+node index.js -e test -f ./notifiche.csv
+
+node index.js --envName test --csvFile ./notifiche.csv
+```
+
+### Parametri
+
+- `--envName`, `-e`: Ambiente di destinazione (uat|test|prod|hotfix)
+- `--csvFile`, `-f`: Percorso del file CSV
+- `--help`, `-h`: Visualizza il messaggio di aiuto
+
+## Note
+
+- Lo script utilizza AWS SSM per il port forwarding
+- Le notifiche vengono processate in base allo stato della notifica analogica:
+  - Chiamata POST all'API `/ext-registry-private/cost-update` di External Registries per: VALIDATION, REQUEST_REFUSED, NOTIFICATION_CANCELLED
+  - Invio evento su coda SQS `pn-deliverypush_to_externalregistries` per: SEND_ANALOG_DOMICILE_ATTEMPT_0, SEND_ANALOG_DOMICILE_ATTEMPT_1, SEND_SIMPLE_REGISTERED_LETTER

--- a/update-analog-costs/index.js
+++ b/update-analog-costs/index.js
@@ -1,0 +1,209 @@
+import { parse } from 'csv-parse/sync';
+import fs from 'fs';
+import axios from 'axios';
+import { parseArgs } from 'util';
+import { AwsClientsWrapper } from "pn-common";
+
+const REQUIRED_COLUMNS = [
+  'IUN', 'timelineElementId', 'category', 'costo timelineElementId',
+  'vat', 'recipientIndex', 'noticeCode', 'creditorTaxId',
+  'eventTimestamp', 'notificationFeePolicy', 'paFee'
+];
+
+const INSTANCE_MAP = {
+  test: 'i-0c7b5a5e1e47dcdff',
+  uat: 'i-08a957490340bdeb2',
+  hotfix: 'i-00fce6a84f7536813',
+  prod: 'i-08d32e04a6fbbcb77'
+};
+
+const HOST_MAP = {
+  test: 'internal-EcsA-20230504103152508600000011-1839177861.eu-south-1.elb.amazonaws.com',
+  uat: 'internal-EcsA-20230508132226979200000016-2130814132.eu-south-1.elb.amazonaws.com',
+  hotfix: 'internal-EcsA-20230707140125848600000001-1120454561.eu-south-1.elb.amazonaws.com',
+  prod: 'internal-EcsA-20230522152202180500000011-96161141.eu-south-1.elb.amazonaws.com'
+};
+
+const API_CATEGORIES = ['VALIDATION', 'REQUEST_REFUSED', 'NOTIFICATION_CANCELLED'];
+const SQS_CATEGORIES = ['SEND_ANALOG_DOMICILE_ATTEMPT_0', 'SEND_ANALOG_DOMICILE_ATTEMPT_1', 'SEND_SIMPLE_REGISTERED_LETTER'];
+
+/**
+ * Validates command line arguments
+ * @returns {Object} Parsed and validated arguments
+ */
+function validateArgs() {
+    const usage = `
+Usage: node index.js --envName|-e <environment> --csvFile|-f <path>
+
+Description:
+    Updates analog notification costs through API calls and SQS messages.
+
+Parameters:
+    --envName, -e     Required. Environment to update (test|uat|hotfix|prod)
+    --csvFile, -f     Required. Path to the CSV file containing notification data
+    --help, -h        Display this help message`;
+
+    const args = parseArgs({
+        options: {
+            envName: { type: "string", short: "e" },
+            csvFile: { type: "string", short: "f" },
+            help: { type: "boolean", short: "h" }
+        },
+        strict: true
+    });
+
+    if (args.values.help) {
+        console.log(usage);
+        process.exit(0);
+    }
+
+    if (!args.values.envName || !args.values.csvFile) {
+        console.error("Error: Missing required parameters");
+        console.log(usage);
+        process.exit(1);
+    }
+
+    if (!INSTANCE_MAP[args.values.envName]) {
+        console.error(`Error: Invalid environment. Must be one of: ${Object.keys(INSTANCE_MAP).join(', ')}`);
+        process.exit(1);
+    }
+
+    return args.values;
+}
+
+/**
+ * Validates and parses the input CSV file
+ * @param {string} filePath - Path to CSV file
+ * @returns {Array<Object>} Parsed notifications
+ */
+function parseCsvFile(filePath) {
+    try {
+        const csvContent = fs.readFileSync(filePath, 'utf-8');
+        const notifications = parse(csvContent, { columns: true, skip_empty_lines: true });
+
+        // Validate CSV structure
+        const headers = Object.keys(notifications[0]);
+        const missingColumns = REQUIRED_COLUMNS.filter(col => !headers.includes(col));
+        if (missingColumns.length > 0) {
+            throw new Error(`Missing required columns: ${missingColumns.join(', ')}`);
+        }
+
+        return notifications;
+    } catch (error) {
+        console.error('Error reading/parsing CSV file:', error);
+        process.exit(1);
+    }
+}
+
+
+/**
+ * Processes a single notification by handling it either as an API request or SQS message based on its category
+ * @param {Object} notification - The notification to be processed containing category information
+ * @param {AWS.SQS} awsClient - The AWS SQS client instance
+ * @param {string} queueUrl - The URL of the SQS queue
+ * @returns {Promise<void>}
+ */
+async function processNotification(notification, awsClient, queueUrl) {
+  if (API_CATEGORIES.includes(notification.category)) {
+    await handleApiRequest(notification);
+  } else if (SQS_CATEGORIES.includes(notification.category)) {
+    await handleSqsMessage(notification, awsClient, queueUrl);
+  }
+}
+
+async function handleApiRequest(notification) {
+  const payload = {
+    notificationStepCost: notification['costo timelineElementId'],
+    iun: notification.IUN,
+    paymentsInfoForRecipients: [{
+      recIndex: notification.recipientIndex,
+      creditorTaxId: notification.creditorTaxId,
+      noticeCode: notification.noticeCode
+    }],
+    eventTimestamp: notification.eventTimestamp,
+    eventStorageTimestamp: notification.eventTimestamp,
+    updateCostPhase: notification.category
+  };
+
+  try {
+    await axios.post('http://localhost:8888/ext-registry-private/cost-update', payload);
+    console.log(`API request successful for IUN ${notification.IUN}`);
+  } catch (error) {
+    console.error(`API request failed for IUN ${notification.IUN}:`, error.message);
+  }
+}
+
+async function handleSqsMessage(notification, awsClient, queueUrl) {
+  const messageAttributes = {
+    iun: { DataType: 'String', StringValue: notification.IUN },
+    eventType: { DataType: 'String', StringValue: 'UPDATE_COST_PHASE_EVENT' }
+  };
+
+  const messageBody = {
+    iun: notification.IUN,
+    recIndex: notification.recipientIndex,
+    notificationStepCost: notification['costo timelineElementId'],
+    vat: notification.vat,
+    eventTimestamp: notification.eventTimestamp,
+    eventStorageTimestamp: notification.eventTimestamp,
+    updateCostPhase: notification.category
+  };
+
+  try {
+    await awsClient._sendSQSMessage(queueUrl, messageBody, 0, messageAttributes);
+    console.log(`SQS message sent for IUN ${notification.IUN}`);
+  } catch (error) {
+    console.error(`SQS send failed for IUN ${notification.IUN}:`, error.message);
+  }
+}
+
+async function main() {
+    const args = validateArgs();
+    const { envName, csvFile } = args;
+
+    const awsClient = new AwsClientsWrapper('core', envName);
+    awsClient._initSSM();
+    awsClient._initSQS();
+
+    let sessionId;
+    try {
+        // Start SSM session
+        sessionId = await awsClient._startSSMPortForwardingSession(
+            INSTANCE_MAP[envName],
+            HOST_MAP[envName],
+            8080,
+            8888
+        );
+
+        // Parse CSV file
+        const notifications = parseCsvFile(csvFile);
+        console.log(`Processing ${notifications.length} notifications...`);
+
+        // Get SQS queue URL
+        const queueUrl = await awsClient._getQueueUrl('pn-deliverypush_to_externalregistries');
+
+        // Process notifications
+        let processed = 0;
+        for (const notification of notifications) {
+            await processNotification(notification, awsClient, queueUrl);
+            processed++;
+            if (processed % 10 === 0) {
+                console.log(`Processed ${processed}/${notifications.length} notifications`);
+            }
+        }
+
+        console.log(`\nCompleted processing ${processed} notifications`);
+
+    } finally {
+        // Cleanup: terminate SSM session
+        if (sessionId) {
+            await awsClient._terminateSSMSession(sessionId);
+            console.log('SSM session terminated');
+        }
+    }
+}
+
+main().catch(err => {
+    console.error('Script failed:', err);
+    process.exit(1);
+});

--- a/update-analog-costs/package-lock.json
+++ b/update-analog-costs/package-lock.json
@@ -1,0 +1,331 @@
+{
+  "name": "update-analog-costs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "update-analog-costs",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.6.7",
+        "csv-parse": "^5.5.3",
+        "pn-common": "file:../pn-common/"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../pn-common": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@aws-sdk/client-athena": "^3.750.0",
+        "@aws-sdk/client-cloudformation": "^3.658.0",
+        "@aws-sdk/client-cloudwatch": "^3.709.0",
+        "@aws-sdk/client-cloudwatch-logs": "^3.614.0",
+        "@aws-sdk/client-dynamodb": "^3.602.0",
+        "@aws-sdk/client-ecs": "^3.731.1",
+        "@aws-sdk/client-eventbridge": "^3.614.0",
+        "@aws-sdk/client-kinesis": "^3.614.0",
+        "@aws-sdk/client-kms": "^3.670.0",
+        "@aws-sdk/client-lambda": "^3.670.0",
+        "@aws-sdk/client-s3": "^3.645.0",
+        "@aws-sdk/client-sqs": "^3.600.0",
+        "@aws-sdk/client-sts": "^3.675.0",
+        "@aws-sdk/credential-provider-ini": "^3.598.0",
+        "@aws-sdk/util-dynamodb": "^3.602.0",
+        "csv-parse": "^5.5.6"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
+      "integrity": "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/pn-common": {
+      "resolved": "../pn-common",
+      "link": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/update-analog-costs/package.json
+++ b/update-analog-costs/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "update-analog-costs",
+  "version": "1.0.0",
+  "description": "Script to update analog notification costs",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "author": "PagoPA",
+  "license": "ISC",
+  "dependencies": {
+    "@aws-sdk/client-ssm": "^3.x",
+    "axios": "^1.6.7",
+    "csv-parse": "^5.5.3",
+    "pn-common": "file:../pn-common/"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
Issue JIRA di riferimento: [GO-116](https://pagopa.atlassian.net/browse/GO-116)

Lo script permette di aggiornare i costi delle notifiche analogiche attraverso chiamate REST all'API di ExtReg o inserendo messaggi SQS nella coda di comunicazione fra DelPush ed ExtReg a seconda dello stato della notifica. Utilizza AWS SSM per il port forwarding verso l'ALB di CORE per contattare l'API di ExtReg.

Le notifiche vengono processate in base allo stato della notifica analogica:
  - Chiamata POST all'API `/ext-registry-private/cost-update` di External Registries per: VALIDATION, REQUEST_REFUSED, NOTIFICATION_CANCELLED
  - Invio evento su coda SQS `pn-deliverypush_to_externalregistries` per: SEND_ANALOG_DOMICILE_ATTEMPT_0, SEND_ANALOG_DOMICILE_ATTEMPT_1, SEND_SIMPLE_REGISTERED_LETTER