### PR TITLE
ops/GO-187

### DIFF
--- a/check-sent-paper-attachment/index.js
+++ b/check-sent-paper-attachment/index.js
@@ -126,7 +126,7 @@ function logResult(message, checkResult, queueName, timestamp) {
         // For failed checks, log only the required fields
         const outputData = {
             fileKey: message.parsedFileKey,
-            requestId: checkResult.requestId ? `pn-cons-000~${checkResult.requestId}` : null,
+            requestId: checkResult.requestId,
             failureReason: checkResult.reason
         };
         appendFileSync(`results/to_keep_${queueName}_${timestamp}.json`, JSON.stringify(outputData) + '\n');


### PR DESCRIPTION
Issue JIRA di riferimento: [GO-187](https://pagopa.atlassian.net/browse/GO-187)

Aggiornato il comando `set_request_status` per verificare automaticamente il nuovo stato degli oggetti dynamoDB modificati in seguito all’operazione, sfruttando i `ReturnValues`.

I valori restituiti dall'operazione, come da `pn-common`, sono gli `ALL_NEW` e vengono stampati per ciascun oggetto sotto `results/updated.csv`.

[GO-187]: https://pagopa.atlassian.net/browse/GO-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ