### PR TITLE
ops/GO-258

### DIFF
--- a/analyze-safestorage-dlq/README.md
+++ b/analyze-safestorage-dlq/README.md
@@ -19,10 +19,32 @@ Per `pn-ss-main-bucket-events-queue-DLQ`:
 
 1. Legge in input il dump dei messaggi dalla coda DLQ come prelevati dallo script [dump_sqs](https://github.com/pagopa/pn-troubleshooting/tree/main/dump_sqs)
 2. Per ogni messaggio:
-   * Estrae la chiave dell'oggetto S3 dal messaggio
-   * Accerta la presenza nel bucket principale e l'assenza nel bucket di staging
-   * Controlla il documentLogicalState nella tabella `pn-SsDocumenti` in base al suo prefisso
-   * Verifica che la richiesta creazione del documento non sia l'ultimo evento in timeline [solo per documenti PN_AAR e PN_LEGAL_FACTS]
+   * Estrae la *fileKey* S3 e l'*eventName* dal messaggio
+   * Accerta l'assenza della *fileKey* dal bucket di staging
+   * Se l'*eventName* è un `ObjectCreated:Put` verifica che:
+     * La *fileKey* non abbia *deleteMarker* nel bucket principale
+     * Il `documentState` sia *attached* sulla `pn-SsDocumenti`
+   * Se l'*eventName* è un `ObjectRemoved:DeleteMarkerCreated` verifica che:
+     * La *fileKey* abbia *deleteMarker* nel bucket principale
+     * Il `documentState` sia *deleted* sulla `pn-SsDocumenti`
+   * Controlla il `documentLogicalState` sulla `pn-SsDocumenti` in base al tipo di documento:
+     * `ATTACHED`:
+          * PN_PRINTED
+          * PN_NOTIFICATION_ATTACHMENTS
+          * PN_F24_META
+     * `SAVED`:
+          * PN_AAR
+          * PN_F24
+          * PN_F24_META
+          * PN_LEGAL_FACTS
+          * PN_EXTERNAL_LEGAL_FACTS
+          * PN_PAPER_ATTACHMENT
+          * PN_ADDRESSES_RAW
+          * PN_ADDRESSES_NORMALIZED
+          * PN_LOGS_ARCHIVE_AUDIT2Y
+          * PN_LOGS_ARCHIVE_AUDIT5Y
+          * PN_LOGS_ARCHIVE_AUDIT10Y
+   * Solo per PN_AAR e PN_LEGAL_FACTS, la richiesta creazione del documento non deve essere l'ultimo evento in timeline
 
 Per `pn-ss-staging-bucket-events-queue-DLQ` e `pn-ss-transformation-sign-and-timemark-queue-DLQ`:
 

--- a/automation_scripts/check_ec_cartaceo_errors.sh
+++ b/automation_scripts/check_ec_cartaceo_errors.sh
@@ -123,7 +123,8 @@ if [[ ! -f "$ERROR_JSON" ]]; then
   exit 1
 fi
 ERROR_JSON=$(realpath "$ERROR_JSON")
-GENERATED_FILES+=("$ERROR_JSON")
+cp "$WORKDIR/check_status_request/counter.json" "$WORKDIR/check_status_request/${BASENAME}_counter.json"
+GENERATED_FILES+=("$WORKDIR/check_status_request/${BASENAME}_counter.json")
 
 ###########################################################
 # Step 4: Convert the original dump to JSONLine format    #
@@ -161,13 +162,6 @@ GENERATED_FILES+=("$FILTERED_DUMP")
 FILTERED_COUNT=$(wc -l < "$FILTERED_DUMP")
 echo "Filtered dump stored in: $FILTERED_DUMP"
 echo "Total events in filtered dump (to remove): $FILTERED_COUNT"
-
-# Compare counts and warn if total events > removable events
-if [[ $JSONLINE_COUNT -gt $FILTERED_COUNT ]]; then
-    echo "WARNING: Total events count is greater than the count of events to remove."
-    echo "Please analyze the requestIds in error status."
-    echo "See: $(realpath "$ERROR_REQUEST_IDS_LIST")"
-fi
 
 #######################################################
 # Step 7 (optional): Remove events from SQS queue     #


### PR DESCRIPTION
Issue JIRA di riferimento: [GO-258](https://pagopa.atlassian.net/browse/GO-258)

Refactoring dello script di analisi DLQ SafeStorage per differenziare i controlli su S3 e DynamoDB (`pn-SsDocumenti`) in base alla tipologia di evento (`eventName`) presente nella `pn-ss-main-bucket-events-queue-DLQ`. Per ogni messaggio letto dal dump della DLQ:
   * Estrae la *fileKey* S3 e l'*eventName* dal messaggio
   * Accerta l'assenza della *fileKey* dal bucket di staging
   * Se l'*eventName* è un `ObjectCreated:Put` verifica che:
     * La *fileKey* non abbia *deleteMarker* nel bucket principale
     * Il `documentState` sia *attached* sulla `pn-SsDocumenti`
   * Se l'*eventName* è un `ObjectRemoved:DeleteMarkerCreated` verifica che:
     * La *fileKey* abbia *deleteMarker* nel bucket principale
     * Il `documentState` sia *deleted* sulla `pn-SsDocumenti`

I successivi controlli sul `documentLogicalState` sono rimasti invariati, come anche il controllo in *timeline* per i documenti PN_AAR e PN_LEGAL_FACTS.

In aggiunta, sui seguenti script di automazione Bash:
* `check_ec_availability_manager.sh`
* `check_ec_cartaceo_errors.sh`
* `check_ec_to_pc.sh`
* `check_ec_tracker_errors.sh`
* `check_safestorage_dlq.sh`

è stato definito un *array* per tracciare i file di output generati durante l'esecuzione (`GENERATED_FILES`) e una funzione di pulizia (`cleanup`) che viene invocata in caso di errore e di uscita prematura dello script per non lasciare file sparsi nelle cartelle di lavoro.

[GO-258]: https://pagopa.atlassian.net/browse/GO-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ