### PR TITLE
ops/GO-275

### DIFF
--- a/analyze-safestorage-dlq/index.js
+++ b/analyze-safestorage-dlq/index.js
@@ -350,7 +350,7 @@ async function checkDocumentState(awsClient, fileKey, queueConfig, queueName, ev
         if (queueName === 'pn-ss-main-bucket-events-queue-DLQ') {
             let documentStateOk = false;
             if (eventName === 'ObjectCreated:Put') {
-                documentStateOk = item.documentState === 'attached' || item.documentState === 'available';
+                documentStateOk = (item.documentState === 'attached' || item.documentState === 'available');
             } else if (eventName === 'ObjectRemoved:DeleteMarkerCreated') {
                 documentStateOk = item.documentState === 'deleted';
             } else {
@@ -362,7 +362,7 @@ async function checkDocumentState(awsClient, fileKey, queueConfig, queueName, ev
                 actualState: item.documentLogicalState,
                 expectedLogicalState,
                 actualDocumentState: item.documentState,
-                expectedDocumentState: eventName === 'ObjectCreated:Put' ? 'attached' : (eventName === 'ObjectRemoved:DeleteMarkerCreated' ? 'deleted' : undefined)
+                expectedDocumentState: eventName === 'ObjectCreated:Put' ? ['attached', 'available'] : (eventName === 'ObjectRemoved:DeleteMarkerCreated' ? 'deleted' : undefined)
             };
         } else {
             return {

--- a/analyze-safestorage-dlq/index.js
+++ b/analyze-safestorage-dlq/index.js
@@ -157,7 +157,7 @@ async function initializeAwsClients(awsClient) {
         };
 }
 
-function logResult(message, status, reason = '', queueName) {
+function logResult(message, status, reason = '') {
     const clonedMessage = JSON.parse(JSON.stringify(message));
     if (typeof clonedMessage.Body === 'string') {
         clonedMessage.Body = JSON.parse(clonedMessage.Body);
@@ -350,7 +350,7 @@ async function checkDocumentState(awsClient, fileKey, queueConfig, queueName, ev
         if (queueName === 'pn-ss-main-bucket-events-queue-DLQ') {
             let documentStateOk = false;
             if (eventName === 'ObjectCreated:Put') {
-                documentStateOk = item.documentState === 'attached';
+                documentStateOk = item.documentState === 'attached' || item.documentState === 'available';
             } else if (eventName === 'ObjectRemoved:DeleteMarkerCreated') {
                 documentStateOk = item.documentState === 'deleted';
             } else {


### PR DESCRIPTION
Issue JIRA di riferimento: [GO-275](https://pagopa.atlassian.net/browse/GO-275)

Aggiunto lo stato tecnico `available` in aggiunta all’attuale `attached` per eventi del tipo `ObjectCreated:Put` sulla `pn-ss-main-bucket-events-queue-DLQ`

[GO-275]: https://pagopa.atlassian.net/browse/GO-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ