### PR TITLE
ops/GO-502

### DIFF
--- a/prepare_check_retention_attachment/index.js
+++ b/prepare_check_retention_attachment/index.js
@@ -111,9 +111,17 @@ async function main() {
     }
 
     async function _getItemFromPnFutureAction(iunValue) {
-
-        const tableName = "pn-FutureAction"
-        return await awsClientCore._queryRequestByIndex(tableName, 'iun-index', 'iun', iunValue)
+        const tableName = "pn-FutureAction";
+        let lastEvaluatedKey = null;
+        let items = [];
+        do {
+            const results = await awsClientCore._queryRequestByIndex(tableName, 'iun-index', 'iun', iunValue, lastEvaluatedKey);
+            if (results.Items && results.Items.length > 0) {
+                items.push(...results.Items);
+            }
+            lastEvaluatedKey = results.LastEvaluatedKey;
+        } while (lastEvaluatedKey);
+        return { Items: items, Count: items.length };
     }
 
     // try/catch with exit code 1; no return value

--- a/prepare_check_retention_attachment/index.js
+++ b/prepare_check_retention_attachment/index.js
@@ -121,7 +121,7 @@ async function main() {
             }
             lastEvaluatedKey = results.LastEvaluatedKey;
         } while (lastEvaluatedKey);
-        return { Items: items, Count: items.length };
+        return items;
     }
 
     // try/catch with exit code 1; no return value
@@ -262,10 +262,10 @@ async function main() {
                 
                 await _setDocumentStateAttached(fk)
 
-                const result = await _getItemFromPnFutureAction(iun)
+                const futureActions = await _getItemFromPnFutureAction(iun)
 
-                if (result.Count !== 0) {
-                    for (const item of result.Items) {
+                if (futureActions.length !== 0) {
+                    for (const item of futureActions) {
 
                         const pk = item.timeSlot.S // 2025-06-10T21:06
                         const sk = item.actionId.S // check_attachment_retention_iun_KNDA-NPAG-VANA-202502-J-1_scheduling-date_2025-06-10T21:06:01.182068834Z


### PR DESCRIPTION
Issue JIRA di riferimento: [GO-502](https://pagopa.atlassian.net/browse/GO-502)

Rifattorizzazione della funzione `_getItemFromPnFutureAction` del [prepare_check_retention_attachment](https://github.com/pagopa/pn-troubleshooting/tree/main/prepare_check_retention_attachment) in modo che restituisca l'elenco completo di tutti gli elementi che corrispondono alla query mediante un ciclo `do...while` che continua a eseguire query finché `LastEvaluatedKey` è presente nella risposta.



[GO-502]: https://pagopa.atlassian.net/browse/GO-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ