### PR TITLE
feat(PN-20741): change queue name to pn-paper-normalize-address for PREPARE_ASYNC_FLOW events

### DIFF
--- a/redrive_prepare_analog_start_event/index.js
+++ b/redrive_prepare_analog_start_event/index.js
@@ -55,8 +55,7 @@ function _prepareQueueData(requestId){
     "correlationId": null,
     "isAddressRetry":false,
     "attempt":0,
-    "clientId":"",
-    "isF24Flow": false
+    "clientId":""
   }
   return data
 }
@@ -124,7 +123,7 @@ async function main() {
   const awsClient = new AwsClientsWrapper( envName );
   
   console.log('Preparing data...')
-  const queueUrl = await awsClient._getQueueUrl('pn-paper_channel_requests');
+  const queueUrl = await awsClient._getQueueUrl('pn-paper-normalize-address');
 
   console.log('Reading from file...')
 

--- a/redrive_prepare_flow/index.js
+++ b/redrive_prepare_flow/index.js
@@ -43,9 +43,7 @@ function _prepareQueueData(requestId){
     "attempt":0,
     "clientId":""
   }
-  if (envName == 'uat') {
-    data['isF24Flow'] = false
-  }
+
   console.log(data)
   return data
 }
@@ -145,7 +143,7 @@ async function main() {
   const awsClient = new AwsClientsWrapper( envName );
   
   console.log('Preparing data...')
-  const queueUrl = await awsClient._getQueueUrl('pn-paper_channel_requests');
+  const queueUrl = await awsClient._getQueueUrl('pn-paper-normalize-address');
 
   console.log('Reading from file...')
   const fileRows = fs.readFileSync(fileName, { encoding: 'utf8', flag: 'r' }).split('\n').filter( x => x != "")


### PR DESCRIPTION
1. Replaced `pn-paper_channel_requests` to `pn-paper-normalize-address` in `redrive_prepare_flow` and `redrive_prepare_analog_start_event` scrips (because they use `PREPARE_ASYNC_FLOW` events)
2. Removed `isF24Flow` field in payload (the field is not used).